### PR TITLE
修复error队列处理uid的错误

### DIFF
--- a/index.py
+++ b/index.py
@@ -28,7 +28,8 @@ def main(stus):
         for i in range(len(error)-1, -1, -1):
             phone = error[i][0]
             password = error[i][1]
-            uid = error[i][2]
+            device_seed = error[i][2]
+            uid = error[i][3]
 
             msg = check(phone, password, device_seed, uid)
             print(msg)


### PR DESCRIPTION
在[index.py](https://github.com/themanforfree/HAUT-checkin/blob/master/index.py)的第31行写错了，应该是`uid = error[i][3]`。

而且`device_seed`没有写上，不写的话后面一直用的是上一个循环的最后一个人的设备码。

```python
            phone = error[i][0]
            password = error[i][1]
            uid = error[i][2]
```

应该是：

```python
            phone = error[i][0]
            password = error[i][1]
            device_seed = error[i][2]
            uid = error[i][3]
```